### PR TITLE
Added python/rpr module to addon

### DIFF
--- a/build.py
+++ b/build.py
@@ -284,10 +284,6 @@ def hdrpr(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var):
             f"-DTBB_INCLUDE_DIR={bl_libs_dir}/tbb/include",
         ])
 
-        rprusd_py = usd_dir / "lib/python/rpr/RprUsd/__init__.py"
-        print(f"Clear: {rprusd_py}")
-        rprusd_py.write_text("")
-
     finally:
         check_call('git', 'checkout', '--', '*')
         ch_dir(cur_dir)
@@ -359,7 +355,8 @@ def zip_addon(bin_dir):
 
         # copy python rpr
         pyrpr_dir = bin_dir / 'USD/install/lib/python/rpr'
-        for f in pyrpr_dir.glob("**/*"):
+        (pyrpr_dir / "RprUsd/__init__.py").write_text("")
+        for f in (pyrpr_dir / "__init__.py", pyrpr_dir / "RprUsd/__init__.py"):
             yield f, Path("libs") / f.relative_to(pyrpr_dir.parent.parent)
 
     def get_version():

--- a/build.py
+++ b/build.py
@@ -72,7 +72,7 @@ def _cmake(d, compiler, jobs, build_var, args):
 
     if build_var == 'relwithdebuginfo' and OS == 'Windows':
         # disabling optimization for debug purposes
-        build_args.append(f'USD,-DCMAKE_CXX_FLAGS_RELWITHDEBINFO="/Od"')
+        build_args.append(f'-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=/Od')
 
     build_name = {'release': 'Release',
                   'debug': 'Debug',
@@ -284,6 +284,10 @@ def hdrpr(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var):
             f"-DTBB_INCLUDE_DIR={bl_libs_dir}/tbb/include",
         ])
 
+        rprusd_py = usd_dir / "lib/python/rpr/RprUsd/__init__.py"
+        print(f"Clear: {rprusd_py}")
+        rprusd_py.write_text("")
+
     finally:
         check_call('git', 'checkout', '--', '*')
         ch_dir(cur_dir)
@@ -352,6 +356,11 @@ def zip_addon(bin_dir):
             rel_path = f.relative_to(plugin_path.parent)
             if any(p in rel_path.parts for p in ("hdRpr", "rprUsd", 'rprUsdMetadata')):
                 yield f, libs_rel_path.parent / rel_path
+
+        # copy python rpr
+        pyrpr_dir = bin_dir / 'USD/install/lib/python/rpr'
+        for f in pyrpr_dir.glob("**/*"):
+            yield f, Path("libs") / f.relative_to(pyrpr_dir.parent.parent)
 
     def get_version():
         # getting buid version

--- a/src/hydrarpr/engine.py
+++ b/src/hydrarpr/engine.py
@@ -14,6 +14,7 @@
 # ********************************************************************
 import os
 from pathlib import Path
+import sys
 
 import bpy
 import bpy_hydra
@@ -35,6 +36,7 @@ class RPRHydraRenderEngine(bpy_hydra.HydraRenderEngine):
     def register(cls):
         super().register()
         os.environ['PATH'] = os.environ['PATH'] + os.pathsep + str(LIBS_DIR / "lib")
+        sys.path.append(str(LIBS_DIR / "python"))
         bpy_hydra.register_plugins([str(LIBS_DIR / "plugin")])
 
     def get_delegate_settings(self, engine_type):


### PR DESCRIPTION
### Purpose
Fix warning in loading hydrarpr addon
```
Warning: in Tf_PyLoadScriptModule at line 123 of D:\amd\blender-git\RPRHydraRenderBlenderAddon\USD\pxr\base\tf\pyUtils.cpp -- Import failed for module 'rpr.RprUsd'!
ModuleNotFoundError: No module named 'rpr'
```

### Technical steps
Added to addon `python/rpr` module.
Added  `python/rpr` to sys.path.
Additional fix of build in relwithdebuginfo mode.